### PR TITLE
Check for bad filename on the filesystem

### DIFF
--- a/dsapp-test.sh
+++ b/dsapp-test.sh
@@ -5377,6 +5377,11 @@ EOF
 					echo -e "\nWARNING:"
 					printf "%10d entires missing from the file system!\n" $i;
 				fi
+				i=`egrep -v '^[0-9a-f]{32}$' /tmp/dsapp-attachments-files | wc -l`
+				if [ $i -gt 0 ]; then
+					echo -e "\nWARNING:"
+					printf "%10d files with bad filename on the file system!\n" $i;
+				fi
 				echo
 				eContinue;
 				;;


### PR DESCRIPTION
Check for filenames which aren't 32 hexadecimal characters long.

Adding to the previous check, this one catch another case of left over file from either GroupWise Mobile Server or previous versions of Datasync.

Or they could be valid file name for what I know but if found it odd to find filenames suich as this:

/var/lib/datasync/mobility/attachments/20/611654

Oddly, I can match it inside the database, table attachments, column filestoreid.